### PR TITLE
Bug fix for field index

### DIFF
--- a/lib/thrash/protocol/binary.ex
+++ b/lib/thrash/protocol/binary.ex
@@ -141,7 +141,7 @@ defmodule Thrash.Protocol.Binary do
 
   defp header(type, ix) do
     quote do
-      << unquote(Type.id(type)), unquote(ix) + 1 :: 16-unsigned >>
+      << unquote(Type.id(type)), unquote(ix + 1) :: 16-unsigned >>
     end
   end
 


### PR DESCRIPTION
An error was generated when compiling files that "use Thrash.Protocol.Binary".    The only thing I can think of is I am using 1.5.1 which could have change how some of the matching occurs.

** (CompileError) test/simple_struct.ex:14: cannot invoke remote function :erlang.+/2 inside match
    (elixir) src/elixir_bitstring.erl:65: :elixir_bitstring.expand_expr/4
    (elixir) src/elixir_bitstring.erl:19: :elixir_bitstring.expand/6
    (elixir) src/elixir_bitstring.erl:9: :elixir_bitstring.expand/4


After some investigation it looks like we should be evaluating ix + 1 prior to performing any matching, so I changed that and all tests passed.

I'm not entirely sure this is an appropriate fix, though I have tested thrift object (de)serialization and everything works including the existing test cases.